### PR TITLE
Fixed incorrect escaping of group name when sending LDAP request in GroupsLoader

### DIFF
--- a/lib/Handlers/GroupsLoader.php
+++ b/lib/Handlers/GroupsLoader.php
@@ -146,7 +146,7 @@ class GroupsLoader extends BaseHandler
 	 */
 	protected function getGroupMemberOf(Manager $ldap, $groupDn)
 	{
-		return $ldap->search(null, str_replace(':group:', ldap_escape($groupDn, null, LDAP_ESCAPE_DN), self::$GroupMemberOfLookup));
+		return $ldap->search(null, str_replace(':group:', ldap_escape($groupDn, null, LDAP_ESCAPE_FILTER), self::$GroupMemberOfLookup));
 	}
 }
 


### PR DESCRIPTION
We found out that incorrect escaping method was used. Although it looks that we should have used *DN version as we are escaping group dn, *FILTER variant is the correct one to use as we use the DN in the search filter. Groups that contained parentheses produced a search failed error.